### PR TITLE
docs(contributing): Contributing.md doc links to spinnaker.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Interested in contributing to Spinnaker? Please review the [contribution documentation](https://www.spinnaker.io/community/contributing/).


### PR DESCRIPTION
Adds a default `CONTRIBUTING.md` for the org

Related to: https://github.com/spinnaker/spinnaker/pull/4604